### PR TITLE
Authentication for Polypheny-Control

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,7 @@ dependencies {
     // Apache Commons Stuff
     implementation group: "org.apache.commons", name: "commons-lang3", version: "3.9" // Apache 2.0
     implementation group: "commons-io", name: "commons-io", version: "2.6" // Apache 2.0
+    implementation group: "commons-codec", name: "commons-codec", version: "1.15" // Apache 2.0
 
     implementation group: "com.google.guava", name: "guava", version: "30.1-jre" // Apache 2.0
 

--- a/src/main/java/org/polypheny/control/authentication/AuthenticationContext.java
+++ b/src/main/java/org/polypheny/control/authentication/AuthenticationContext.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019-2021 The Polypheny Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.polypheny.control.authentication;
+
+
+public enum AuthenticationContext {
+    CLI,
+    LOCALHOST,
+    REMOTEHOST
+}

--- a/src/main/java/org/polypheny/control/authentication/AuthenticationDataManager.java
+++ b/src/main/java/org/polypheny/control/authentication/AuthenticationDataManager.java
@@ -15,7 +15,7 @@ public class AuthenticationDataManager {
         byte[] randomBytes = new byte[13];
         random.nextBytes( randomBytes );
         for ( byte randomByte : randomBytes ) {
-            int index = ( randomByte < 0 ? -1 * randomByte : randomByte ) % characters.length();
+            int index = (randomByte < 0 ? -1 * randomByte : randomByte) % characters.length();
             salt.append( characters.charAt( index ) );
         }
         return salt.toString();

--- a/src/main/java/org/polypheny/control/authentication/AuthenticationDataManager.java
+++ b/src/main/java/org/polypheny/control/authentication/AuthenticationDataManager.java
@@ -1,0 +1,47 @@
+package org.polypheny.control.authentication;
+
+
+import java.security.SecureRandom;
+import java.util.HashMap;
+import org.apache.commons.codec.digest.Crypt;
+
+
+public class AuthenticationDataManager {
+
+    private static String generateRandomSalt() {
+        String characters = "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+        StringBuilder salt = new StringBuilder( "$6$" );    // Using SHA512
+        SecureRandom random = new SecureRandom();
+        byte[] randomBytes = new byte[13];
+        random.nextBytes( randomBytes );
+        for ( byte randomByte : randomBytes ) {
+            int index = ( randomByte < 0 ? -1 * randomByte : randomByte ) % characters.length();
+            salt.append( characters.charAt( index ) );
+        }
+        return salt.toString();
+    }
+
+
+    private static String encryptPassword( String password ) {
+        String salt = generateRandomSalt();
+        return Crypt.crypt( password, salt );
+    }
+
+
+    public static void addAuthenticationData( String name, String password ) {
+        HashMap<String, String> authenticationData = AuthenticationFileManager.getAuthenticationData();
+        authenticationData.put( name, encryptPassword( password ) );
+    }
+
+
+    public static void removeAuthenticationData( String name ) {
+        HashMap<String, String> authenticationData = AuthenticationFileManager.getAuthenticationData();
+        authenticationData.remove( name );
+    }
+
+
+    public static void modifyAuthenticationData( String name, String password ) {
+        HashMap<String, String> authenticationData = AuthenticationFileManager.getAuthenticationData();
+        authenticationData.replace( name, encryptPassword( password ) );
+    }
+}

--- a/src/main/java/org/polypheny/control/authentication/AuthenticationFileManager.java
+++ b/src/main/java/org/polypheny/control/authentication/AuthenticationFileManager.java
@@ -1,0 +1,69 @@
+package org.polypheny.control.authentication;
+
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map.Entry;
+import lombok.val;
+import org.polypheny.control.control.ConfigManager;
+
+
+public class AuthenticationFileManager {
+
+    private static File authenticationFile;
+    private static HashMap<String, String> authenticationFileData;
+
+
+    // Key is Name; Value is Encrypted Password
+    public static HashMap<String, String> getAuthenticationFileData() {
+        if ( authenticationFileData == null ) {
+            val config = ConfigManager.getConfig();
+            String workingDir = config.getString( "pcrtl.workingdir" );
+            authenticationFile = new File( workingDir, "passwd" );
+            authenticationFileData = new HashMap<>();
+            try ( FileReader fileReader = new FileReader( authenticationFile );
+                    BufferedReader bufferedReader = new BufferedReader( fileReader ) ) {
+                bufferedReader.lines().map( line -> line.split( "\\s" ) ).forEach( data -> {
+                    if ( data.length == 2 ) {
+                        authenticationFileData.put( data[0], data[1] );
+                    } else {
+                        // Happens only if file format was changed
+                        // TODO: Throw exception
+                    }
+                } );
+            } catch ( IOException e ) {
+                e.printStackTrace();
+            }
+        }
+        return authenticationFileData;
+    }
+
+
+    public static void setAuthenticationFileData( HashMap<String, String> _authenticationFileData ) {
+        if ( _authenticationFileData == null ) {
+            throw new NullPointerException( "Data to be written cannot be null." );
+        }
+        if ( authenticationFile == null ) {
+            val config = ConfigManager.getConfig();
+            String workingDir = config.getString( "pcrtl.workingdir" );
+            authenticationFile = new File( workingDir, "passwd" );
+        }
+        authenticationFileData = _authenticationFileData;
+        try ( FileWriter fileWriter = new FileWriter( authenticationFile );
+                BufferedWriter bufferedWriter = new BufferedWriter( fileWriter ) ) {
+            for ( Entry<String, String> entry : authenticationFileData.entrySet() ) {
+                String name = entry.getKey();
+                String password = entry.getValue();
+                bufferedWriter.write( name + " " + password + "\n" );
+            }
+        } catch ( IOException e ) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/org/polypheny/control/authentication/AuthenticationFileManager.java
+++ b/src/main/java/org/polypheny/control/authentication/AuthenticationFileManager.java
@@ -16,7 +16,7 @@ import org.polypheny.control.control.ConfigManager;
 public class AuthenticationFileManager {
 
     private static File authenticationFile;
-    private static HashMap<String, String> authenticationFileData;
+    private static HashMap<String, String> authenticationData;
 
 
     private static void loadAuthenticationFile() {
@@ -28,38 +28,43 @@ public class AuthenticationFileManager {
     }
 
 
-    // Key is Name; Value is Encrypted Password
-    public static HashMap<String, String> getAuthenticationFileData() {
-        if ( authenticationFileData == null ) {
+    private static void loadAuthenticationDataFromFile() {
+        if ( authenticationData == null ) {
             loadAuthenticationFile();
-            authenticationFileData = new HashMap<>();
+            authenticationData = new HashMap<>();
             try ( FileReader fileReader = new FileReader( authenticationFile );
                     BufferedReader bufferedReader = new BufferedReader( fileReader ) ) {
                 bufferedReader.lines().map( line -> line.split( "\\s" ) ).forEach( data -> {
                     if ( data.length == 2 ) {
-                        authenticationFileData.put( data[0], data[1] );
+                        authenticationData.put( data[0], data[1] );
                     } else {
                         // Happens only if file format was changed
-                        // TODO: Throw exception
+                        throw new RuntimeException( "Authentication File Data Format Invalid." );
                     }
                 } );
             } catch ( IOException e ) {
                 e.printStackTrace();
             }
         }
-        return authenticationFileData;
     }
 
 
-    public static void setAuthenticationFileData( HashMap<String, String> _authenticationFileData ) {
-        if ( _authenticationFileData == null ) {
-            throw new NullPointerException( "Data to be written cannot be null." );
+    // Key is Name; Value is Encrypted Password
+    public static HashMap<String, String> getAuthenticationData() {
+        loadAuthenticationDataFromFile();
+        return authenticationData;
+    }
+
+
+    public static void writeAuthenticationDataToFile() {
+        if ( authenticationData == null ) {
+            // Data was never modified. So ignore call.
+            return;
         }
         try ( FileWriter fileWriter = new FileWriter( authenticationFile );
                 BufferedWriter bufferedWriter = new BufferedWriter( fileWriter ) ) {
             loadAuthenticationFile();
-            authenticationFileData = _authenticationFileData;
-            for ( Entry<String, String> entry : authenticationFileData.entrySet() ) {
+            for ( Entry<String, String> entry : authenticationData.entrySet() ) {
                 String name = entry.getKey();
                 String password = entry.getValue();
                 bufferedWriter.write( name + " " + password + "\n" );

--- a/src/main/java/org/polypheny/control/authentication/AuthenticationFileManager.java
+++ b/src/main/java/org/polypheny/control/authentication/AuthenticationFileManager.java
@@ -1,6 +1,7 @@
 package org.polypheny.control.authentication;
 
 
+import com.typesafe.config.ConfigFactory;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -10,7 +11,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map.Entry;
 import lombok.val;
-import org.polypheny.control.control.ConfigManager;
 
 
 public class AuthenticationFileManager {
@@ -21,7 +21,7 @@ public class AuthenticationFileManager {
 
     private static void loadAuthenticationFile() {
         if ( authenticationFile == null ) {
-            val config = ConfigManager.getConfig();
+            val config = ConfigFactory.load();
             String workingDir = config.getString( "pcrtl.workingdir" );
             authenticationFile = new File( workingDir, "passwd" );
         }

--- a/src/main/java/org/polypheny/control/authentication/AuthenticationFileManager.java
+++ b/src/main/java/org/polypheny/control/authentication/AuthenticationFileManager.java
@@ -1,7 +1,7 @@
 package org.polypheny.control.authentication;
 
 
-import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.Config;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -10,7 +10,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map.Entry;
-import lombok.val;
+import org.polypheny.control.control.ConfigManager;
 
 
 public class AuthenticationFileManager {
@@ -21,15 +21,16 @@ public class AuthenticationFileManager {
 
     private static void loadAuthenticationFile() {
         if ( authenticationFile == null ) {
-            val config = ConfigFactory.load();
+            Config config = ConfigManager.getConfig();
             String workingDir = config.getString( "pcrtl.workingdir" );
             authenticationFile = new File( workingDir, "passwd" );
-            if ( !authenticationFile.exists() ) {
-                try {
-                    authenticationFile.createNewFile();
-                } catch ( IOException e ) {
-//                    e.printStackTrace();
-                }
+
+            try {
+                // Making sure parent directory exists, so that writes don't fail.
+                authenticationFile.getParentFile().mkdirs();
+                authenticationFile.createNewFile();
+            } catch ( IOException ex ) {
+                throw new RuntimeException( "Cannot Create File: " + authenticationFile.getAbsolutePath() );
             }
         }
     }
@@ -50,7 +51,7 @@ public class AuthenticationFileManager {
                     }
                 } );
             } catch ( IOException e ) {
-                // e.printStackTrace();
+                throw new RuntimeException( "Cannot Read From File: " + authenticationFile.getAbsolutePath() );
             }
         }
     }
@@ -77,7 +78,7 @@ public class AuthenticationFileManager {
                 bufferedWriter.write( name + " " + password + "\n" );
             }
         } catch ( IOException e ) {
-            // e.printStackTrace();
+            throw new RuntimeException( "Cannot Write To File: " + authenticationFile.getAbsolutePath() );
         }
     }
 }

--- a/src/main/java/org/polypheny/control/authentication/AuthenticationFileManager.java
+++ b/src/main/java/org/polypheny/control/authentication/AuthenticationFileManager.java
@@ -4,7 +4,6 @@ package org.polypheny.control.authentication;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -20,12 +19,19 @@ public class AuthenticationFileManager {
     private static HashMap<String, String> authenticationFileData;
 
 
-    // Key is Name; Value is Encrypted Password
-    public static HashMap<String, String> getAuthenticationFileData() {
-        if ( authenticationFileData == null ) {
+    private static void loadAuthenticationFile() {
+        if ( authenticationFile == null ) {
             val config = ConfigManager.getConfig();
             String workingDir = config.getString( "pcrtl.workingdir" );
             authenticationFile = new File( workingDir, "passwd" );
+        }
+    }
+
+
+    // Key is Name; Value is Encrypted Password
+    public static HashMap<String, String> getAuthenticationFileData() {
+        if ( authenticationFileData == null ) {
+            loadAuthenticationFile();
             authenticationFileData = new HashMap<>();
             try ( FileReader fileReader = new FileReader( authenticationFile );
                     BufferedReader bufferedReader = new BufferedReader( fileReader ) ) {
@@ -49,14 +55,10 @@ public class AuthenticationFileManager {
         if ( _authenticationFileData == null ) {
             throw new NullPointerException( "Data to be written cannot be null." );
         }
-        if ( authenticationFile == null ) {
-            val config = ConfigManager.getConfig();
-            String workingDir = config.getString( "pcrtl.workingdir" );
-            authenticationFile = new File( workingDir, "passwd" );
-        }
-        authenticationFileData = _authenticationFileData;
         try ( FileWriter fileWriter = new FileWriter( authenticationFile );
                 BufferedWriter bufferedWriter = new BufferedWriter( fileWriter ) ) {
+            loadAuthenticationFile();
+            authenticationFileData = _authenticationFileData;
             for ( Entry<String, String> entry : authenticationFileData.entrySet() ) {
                 String name = entry.getKey();
                 String password = entry.getValue();

--- a/src/main/java/org/polypheny/control/authentication/AuthenticationFileManager.java
+++ b/src/main/java/org/polypheny/control/authentication/AuthenticationFileManager.java
@@ -43,7 +43,7 @@ public class AuthenticationFileManager {
                     }
                 } );
             } catch ( IOException e ) {
-                e.printStackTrace();
+                // e.printStackTrace();
             }
         }
     }
@@ -70,7 +70,7 @@ public class AuthenticationFileManager {
                 bufferedWriter.write( name + " " + password + "\n" );
             }
         } catch ( IOException e ) {
-            e.printStackTrace();
+            // e.printStackTrace();
         }
     }
 }

--- a/src/main/java/org/polypheny/control/authentication/AuthenticationFileManager.java
+++ b/src/main/java/org/polypheny/control/authentication/AuthenticationFileManager.java
@@ -24,6 +24,13 @@ public class AuthenticationFileManager {
             val config = ConfigFactory.load();
             String workingDir = config.getString( "pcrtl.workingdir" );
             authenticationFile = new File( workingDir, "passwd" );
+            if ( !authenticationFile.exists() ) {
+                try {
+                    authenticationFile.createNewFile();
+                } catch ( IOException e ) {
+//                    e.printStackTrace();
+                }
+            }
         }
     }
 
@@ -61,9 +68,9 @@ public class AuthenticationFileManager {
             // Data was never modified. So ignore call.
             return;
         }
+        loadAuthenticationFile();
         try ( FileWriter fileWriter = new FileWriter( authenticationFile );
                 BufferedWriter bufferedWriter = new BufferedWriter( fileWriter ) ) {
-            loadAuthenticationFile();
             for ( Entry<String, String> entry : authenticationData.entrySet() ) {
                 String name = entry.getKey();
                 String password = entry.getValue();

--- a/src/main/java/org/polypheny/control/authentication/AuthenticationManager.java
+++ b/src/main/java/org/polypheny/control/authentication/AuthenticationManager.java
@@ -1,0 +1,15 @@
+package org.polypheny.control.authentication;
+
+
+import java.util.HashMap;
+import org.apache.commons.codec.digest.Crypt;
+
+
+public class AuthenticationManager {
+
+    public static boolean clientExists( String name, String password ) {
+        HashMap<String, String> authenticationData = AuthenticationFileManager.getAuthenticationData();
+        String encryptedPassword = authenticationData.get( name );
+        return encryptedPassword != null && encryptedPassword.equals( Crypt.crypt( password, encryptedPassword ) );
+    }
+}

--- a/src/main/java/org/polypheny/control/authentication/AuthenticationUtils.java
+++ b/src/main/java/org/polypheny/control/authentication/AuthenticationUtils.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019-2021 The Polypheny Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.polypheny.control.authentication;
+
+
+import com.typesafe.config.Config;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import org.polypheny.control.control.ConfigManager;
+
+
+public class AuthenticationUtils {
+    private static boolean authenticationEnabled;
+    private static boolean localAuthenticationEnabled;
+    private static boolean cliAuthenticationEnabled;
+
+    static {
+        Config config = ConfigManager.getConfig();
+        authenticationEnabled = config.getBoolean( "pcrtl.auth.enable" );
+        localAuthenticationEnabled = authenticationEnabled && config.getBoolean( "pcrtl.auth.local" );
+        cliAuthenticationEnabled = authenticationEnabled && config.getBoolean( "pcrtl.auth.cli" );
+    }
+
+    public static boolean shouldAuthenticate(AuthenticationContext context) {
+        if ( context == AuthenticationContext.REMOTEHOST ) {
+            return authenticationEnabled;
+        } else if ( context == AuthenticationContext.LOCALHOST ) {
+            return localAuthenticationEnabled;
+        } else {
+            return cliAuthenticationEnabled;
+        }
+    }
+
+    public static AuthenticationContext getContextForHost(String host) {
+        try {
+            InetAddress clientIPAddress = InetAddress.getByName( host );
+            InetAddress serverIPAddress = InetAddress.getLocalHost();
+            if ( clientIPAddress.isLoopbackAddress() || clientIPAddress.equals( serverIPAddress ) ) {
+                return AuthenticationContext.LOCALHOST;
+            } else {
+                return AuthenticationContext.REMOTEHOST;
+            }
+        } catch ( UnknownHostException e ) {
+            throw new RuntimeException( "Cannot resolve host: " + host );
+        }
+    }
+}

--- a/src/main/java/org/polypheny/control/client/ClientData.java
+++ b/src/main/java/org/polypheny/control/client/ClientData.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019-2021 The Polypheny Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.polypheny.control.client;
+
+
+public class ClientData {
+
+    private final ClientType clientType;
+    private final String username;
+    private final String password;
+
+
+    public ClientData( ClientType clientType, String username, String password ) {
+        this.clientType = clientType;
+        this.username = username;
+        this.password = password;
+    }
+
+
+    public ClientType getClientType() {
+        return clientType;
+    }
+
+
+    public String getUsername() {
+        return username;
+    }
+
+
+    public String getPassword() {
+        return password;
+    }
+}

--- a/src/main/java/org/polypheny/control/client/ClientType.java
+++ b/src/main/java/org/polypheny/control/client/ClientType.java
@@ -16,6 +16,7 @@
 
 package org.polypheny.control.client;
 
+
 public enum ClientType {
     UNKNOWN, BROWSER, BENCHMARKER
 }

--- a/src/main/java/org/polypheny/control/client/HttpConnector.java
+++ b/src/main/java/org/polypheny/control/client/HttpConnector.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019-2021 The Polypheny Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.polypheny.control.client;
+
+
+import kong.unirest.Cookie;
+import kong.unirest.GetRequest;
+import kong.unirest.HttpRequest;
+import kong.unirest.HttpRequestWithBody;
+import kong.unirest.HttpResponse;
+import kong.unirest.MultipartBody;
+import kong.unirest.Unirest;
+
+interface POSTComposer {
+    MultipartBody composeRequest( HttpRequestWithBody request );
+}
+
+interface SessionTimeoutHandler {
+    boolean handleSessionTimeout();
+}
+
+public class HttpConnector {
+
+    private Cookie jsessionid;
+    private SessionTimeoutHandler sessionTimeoutHandler;
+
+
+    public HttpConnector() {
+        Unirest.config().connectTimeout( 0 );
+        Unirest.config().socketTimeout( 0 );
+        Unirest.config().concurrency( 200, 100 );
+    }
+
+    public void authenticate( String url, String username, String password ) {
+        HttpResponse<String> response = Unirest.get( url )
+                .basicAuth( username, password )
+                .asString();
+        jsessionid = response.getCookies().getNamed( "JSESSIONID" );
+    }
+
+    public HttpResponse<String> post( String url, POSTComposer composer ) {
+        HttpRequestWithBody request = Unirest.post( url );
+        MultipartBody multipartBody = composer.composeRequest( request );
+        ensureJSESSIONIDAttached( multipartBody );
+        HttpResponse<String> response = multipartBody.asString();
+
+        // Handle Session Timeout
+        if ( response.getStatus() == 401 ) {
+            boolean shouldResendRequest = sessionTimeoutHandler.handleSessionTimeout();
+            if ( shouldResendRequest ) {
+                return post( url, composer );
+            }
+        }
+
+        return response;
+    }
+
+    public HttpResponse<String> get( String url ) {
+        GetRequest request = Unirest.get( url );
+        ensureJSESSIONIDAttached( request );
+        HttpResponse<String> response = request.asString();
+
+        // Handle Session Timeout
+        if ( response.getStatus() == 401 ) {
+            boolean shouldResendRequest = sessionTimeoutHandler.handleSessionTimeout();
+            if ( shouldResendRequest ) {
+                return get( url );
+            }
+        }
+
+        return response;
+    }
+
+
+    public void setSessionTimeoutHandler( SessionTimeoutHandler sessionTimeoutHandler ) {
+        this.sessionTimeoutHandler = sessionTimeoutHandler;
+    }
+
+
+    private void ensureJSESSIONIDAttached(HttpRequest request) {
+        if ( jsessionid != null ) {
+            request.cookie( jsessionid );
+        }
+    }
+}

--- a/src/main/java/org/polypheny/control/client/PolyphenyControlConnector.java
+++ b/src/main/java/org/polypheny/control/client/PolyphenyControlConnector.java
@@ -16,6 +16,7 @@
 
 package org.polypheny.control.client;
 
+
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import java.lang.reflect.Type;

--- a/src/main/java/org/polypheny/control/httpinterface/Server.java
+++ b/src/main/java/org/polypheny/control/httpinterface/Server.java
@@ -48,6 +48,15 @@ public class Server {
         javalin.before( ctx -> {
             log.debug( "Received api call: {}", ctx.path() );
 
+            Config config = ConfigManager.getConfig();
+            boolean authenticationEnabled = config.getBoolean( "pcrtl.auth.enable" );
+            if ( !authenticationEnabled ) {
+                if ( ctx.path().equals( "/login.html" ) ) {
+                    ctx.redirect( "/" );
+                }
+                return;
+            }
+
             // If request is for login resources, then do nothing
             boolean loginRes = ctx.path().equals( "/login.html" ) ||
                     ctx.path().endsWith( ".css" ) || ctx.path().endsWith( ".js" );
@@ -55,10 +64,9 @@ public class Server {
                 return;
             }
 
-            Config config = ConfigManager.getConfig();
             String remoteHost = ctx.req.getRemoteHost();
             boolean isLocalUser = remoteHost.equals( "localhost" ) || remoteHost.equals( "127.0.0.1" );
-            boolean authenticateLocalUser = config.getBoolean( "pcrtl.localauth.enable" );
+            boolean authenticateLocalUser = config.getBoolean( "pcrtl.auth.local" );
 
             if ( isLocalUser && !authenticateLocalUser ) {
                 // Request is from local user & Authentication for local user is disabled

--- a/src/main/java/org/polypheny/control/main/ControlCommand.java
+++ b/src/main/java/org/polypheny/control/main/ControlCommand.java
@@ -28,7 +28,7 @@ import org.polypheny.control.httpinterface.Server;
 public class ControlCommand extends AbstractCommand {
 
     @Option(name = { "-p", "--port" }, description = "Overwrite port of the Polypheny Control dashboard")
-    private int port = -1;
+    private final int port = -1;
 
     private volatile boolean running = true;
 
@@ -48,7 +48,7 @@ public class ControlCommand extends AbstractCommand {
         while ( running ) {
             Thread.yield();
             try {
-                Thread.sleep(1000);
+                Thread.sleep( 1000 );
             } catch ( InterruptedException e ) {
                 // ignore
             }

--- a/src/main/java/org/polypheny/control/main/HelpCommand.java
+++ b/src/main/java/org/polypheny/control/main/HelpCommand.java
@@ -34,10 +34,10 @@ public class HelpCommand implements CliRunnable {
     private GlobalMetadata<CliRunnable> global;
 
     @Arguments(description = "Provides the name of the commands you want to provide help for")
-    private List<String> commandNames = new ArrayList<>();
+    private final List<String> commandNames = new ArrayList<>();
 
     @Option(name = "--include-hidden", description = "When set hidden commands and options are shown in help", hidden = true)
-    private boolean includeHidden = false;
+    private final boolean includeHidden = false;
 
 
     @Override

--- a/src/main/java/org/polypheny/control/main/Main.java
+++ b/src/main/java/org/polypheny/control/main/Main.java
@@ -85,6 +85,30 @@ public class Main {
     }
 
 
+    private static void authorizeAdmin() {
+        HashMap<String, String> authenticationData = AuthenticationFileManager.getAuthenticationData();
+        String adminPassword = authenticationData.get( "admin" );
+
+        if ( adminPassword == null ) {
+            System.err.println( "'admin' user does not exist! Please create a admin user before proceeding." );
+            System.exit( 1 );
+        }
+
+        Console console = System.console();
+
+        for ( int i = 1; i <= 3; i++ ) {
+            String password = new String( console.readPassword( "Enter 'admin' password (Try %d/3): ", i ) );
+            if ( !AuthenticationManager.clientExists( "admin", password ) ) {
+                System.err.println( "Incorrect Credentials!" );
+            } else {
+                return;
+            }
+        }
+        System.err.println( "3 incorrect password attempts." );
+        System.exit( 1 );
+    }
+
+
     @Command(name = "start", description = "Start Polypheny-DB")
     public static class StartCommand extends AbstractCommand {
 
@@ -166,11 +190,22 @@ public class Main {
                 return 1;
             }
             String password = new String( console.readPassword( "Password: " ) );
+
+            if ( password.isEmpty() ) {
+                System.err.println( "Password cannot be empty." );
+                System.exit( 1 );
+            }
+
             String confPassword = new String( console.readPassword( "Confirm Password: " ) );
             if ( !password.equals( confPassword ) ) {
                 System.err.println( "Passwords do not match! Try Again!" );
                 return 1;
             }
+
+            if ( !name.equals( "admin" ) ) {
+                authorizeAdmin();
+            }
+
             AuthenticationDataManager.addAuthenticationData( name, password );
             AuthenticationFileManager.writeAuthenticationDataToFile();
             return 0;
@@ -190,6 +225,14 @@ public class Main {
                 System.err.println( "User with the name \"" + name + "\" does not exist!" );
                 return 1;
             }
+
+            if ( !name.equals( "admin" ) ) {
+                authorizeAdmin();
+            } else {
+                System.err.println( "Cannot remove user 'admin'." );
+                System.exit( 1 );
+            }
+
             AuthenticationDataManager.removeAuthenticationData( name );
             AuthenticationFileManager.writeAuthenticationDataToFile();
             return 0;
@@ -210,11 +253,20 @@ public class Main {
                 return 1;
             }
             String password = new String( console.readPassword( "Password: " ) );
+
+            if ( password.isEmpty() ) {
+                System.err.println( "Password cannot be empty." );
+                System.exit( 1 );
+            }
+
             String confPassword = new String( console.readPassword( "Confirm Password: " ) );
             if ( !password.equals( confPassword ) ) {
                 System.err.println( "Passwords do not match! Try Again!" );
                 return 1;
             }
+
+            authorizeAdmin();
+
             AuthenticationDataManager.modifyAuthenticationData( name, password );
             AuthenticationFileManager.writeAuthenticationDataToFile();
             return 0;

--- a/src/main/java/org/polypheny/control/main/Main.java
+++ b/src/main/java/org/polypheny/control/main/Main.java
@@ -21,13 +21,13 @@ import com.github.rvesse.airline.Cli;
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;
 import com.github.rvesse.airline.builder.CliBuilder;
-import com.typesafe.config.Config;
 import java.io.Console;
 import java.util.HashMap;
+import org.polypheny.control.authentication.AuthenticationContext;
 import org.polypheny.control.authentication.AuthenticationDataManager;
 import org.polypheny.control.authentication.AuthenticationFileManager;
 import org.polypheny.control.authentication.AuthenticationManager;
-import org.polypheny.control.control.ConfigManager;
+import org.polypheny.control.authentication.AuthenticationUtils;
 import org.polypheny.control.control.ServiceManager;
 
 
@@ -68,19 +68,13 @@ public class Main {
 
 
     private static void ensureAuthenticated() {
-        Config config = ConfigManager.getConfig();
-        if ( !config.getBoolean( "pctrl.auth.enable" ) ) {
-            return;
-        } else if ( !config.getBoolean( "pctrl.auth.local" ) ) {
-            return;
-        } else if ( !config.getBoolean( "pctrl.auth.cli" ) ) {
-            return;
-        }
+        if ( AuthenticationUtils.shouldAuthenticate( AuthenticationContext.CLI ) ) {
 
-        String[] credentials = getCredentials();
-        if ( !AuthenticationManager.clientExists( credentials[0], credentials[1] ) ) {
-            System.err.println( "Incorrect Credentials! Try Again!" );
-            System.exit( 1 );
+            String[] credentials = getCredentials();
+            if ( !AuthenticationManager.clientExists( credentials[0], credentials[1] ) ) {
+                System.err.println( "Incorrect Credentials! Try Again!" );
+                System.exit( 1 );
+            }
         }
     }
 

--- a/src/main/java/org/polypheny/control/main/Main.java
+++ b/src/main/java/org/polypheny/control/main/Main.java
@@ -69,7 +69,11 @@ public class Main {
 
     private static void ensureAuthenticated() {
         Config config = ConfigManager.getConfig();
-        if ( !config.getBoolean( "pcrtl.localauth.enable" ) ) {
+        if ( !config.getBoolean( "pctrl.auth.enable" ) ) {
+            return;
+        } else if ( !config.getBoolean( "pctrl.auth.local" ) ) {
+            return;
+        } else if ( !config.getBoolean( "pctrl.auth.cli" ) ) {
             return;
         }
 

--- a/src/main/java/org/polypheny/control/main/Main.java
+++ b/src/main/java/org/polypheny/control/main/Main.java
@@ -21,11 +21,13 @@ import com.github.rvesse.airline.Cli;
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;
 import com.github.rvesse.airline.builder.CliBuilder;
+import com.typesafe.config.Config;
 import java.io.Console;
 import java.util.HashMap;
 import org.polypheny.control.authentication.AuthenticationDataManager;
 import org.polypheny.control.authentication.AuthenticationFileManager;
 import org.polypheny.control.authentication.AuthenticationManager;
+import org.polypheny.control.control.ConfigManager;
 import org.polypheny.control.control.ServiceManager;
 
 
@@ -66,6 +68,11 @@ public class Main {
 
 
     private static void ensureAuthenticated() {
+        Config config = ConfigManager.getConfig();
+        if ( !config.getBoolean( "pcrtl.localauth.enable" ) ) {
+            return;
+        }
+
         String[] credentials = getCredentials();
         if ( !AuthenticationManager.clientExists( credentials[0], credentials[1] ) ) {
             System.err.println( "Incorrect Credentials! Try Again!" );

--- a/src/main/java/org/polypheny/control/main/Main.java
+++ b/src/main/java/org/polypheny/control/main/Main.java
@@ -21,6 +21,8 @@ import com.github.rvesse.airline.Cli;
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;
 import com.github.rvesse.airline.builder.CliBuilder;
+import java.io.Console;
+import org.polypheny.control.authentication.AuthenticationManager;
 import org.polypheny.control.control.ServiceManager;
 
 
@@ -49,14 +51,32 @@ public class Main {
     }
 
 
+    private static String[] getCredentials() {
+        Console console = System.console();
+        String name = console.readLine( "Name: " );
+        String password = new String( console.readPassword( "Password: " ) );
+        return new String[]{ name, password };
+    }
+
+
+    private static void ensureAuthenticated() {
+        String[] credentials = getCredentials();
+        if ( !AuthenticationManager.clientExists( credentials[0], credentials[1] ) ) {
+            System.err.println( "Incorrect Credentials! Try Again!" );
+            System.exit( 1 );
+        }
+    }
+
+
     @Command(name = "start", description = "Start Polypheny-DB")
     public static class StartCommand extends AbstractCommand {
 
         @Option(name = { "-t", "--tail" }, description = "Runs (java) tail on the log output")
-        private boolean tail = false;
+        private final boolean tail = false;
 
         //
         private boolean exit = false;
+
 
         @Override
         public int _run_() {
@@ -68,7 +88,7 @@ public class Main {
                 while ( !exit ) {
                     Thread.yield();
                     try {
-                        Thread.sleep(1000);
+                        Thread.sleep( 1000 );
                     } catch ( InterruptedException e ) {
                         // ignore
                     }
@@ -76,6 +96,7 @@ public class Main {
 
                 return 0;
             } else {
+                ensureAuthenticated();
                 return ServiceManager.start( null, false ) ? 0 : 1;
             }
         }
@@ -87,6 +108,7 @@ public class Main {
 
         @Override
         public int _run_() {
+            ensureAuthenticated();
             return ServiceManager.stop( null ) ? 0 : 1;
         }
     }
@@ -97,6 +119,7 @@ public class Main {
 
         @Override
         public int _run_() {
+            ensureAuthenticated();
             return ServiceManager.restart( null, false ) ? 0 : 1;
         }
     }
@@ -107,6 +130,7 @@ public class Main {
 
         @Override
         public int _run_() {
+            ensureAuthenticated();
             return ServiceManager.update( null ) ? 0 : 1;
         }
     }

--- a/src/main/java/org/polypheny/control/main/NotificationManager.java
+++ b/src/main/java/org/polypheny/control/main/NotificationManager.java
@@ -1,8 +1,10 @@
 package org.polypheny.control.main;
 
+
 import java.awt.TrayIcon;
 import java.awt.TrayIcon.MessageType;
 import lombok.Setter;
+
 
 public class NotificationManager {
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -9,7 +9,9 @@ pcrtl {
     logsdir = ${pcrtl.workingdir}${file.separator}logs
     buildmode = "both"
     clean.mode = "never"
-    localauth.enable = false
+    auth.enable = true
+    auth.local = false
+    auth.cli = false
 
     control.configfile = ${pcrtl.workingdir}${file.separator}polypheny-control.properties
     control.port = 8070

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -9,6 +9,7 @@ pcrtl {
     logsdir = ${pcrtl.workingdir}${file.separator}logs
     buildmode = "both"
     clean.mode = "never"
+    localauth.enable = false
 
     control.configfile = ${pcrtl.workingdir}${file.separator}polypheny-control.properties
     control.port = 8070

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -10,11 +10,12 @@ pcrtl {
     buildmode = "both"
     clean.mode = "never"
     auth.enable = true
-    auth.local = false
+    auth.local = true
     auth.cli = false
 
     control.configfile = ${pcrtl.workingdir}${file.separator}polypheny-control.properties
     control.port = 8070
+    control.sessionTimeout = 1000
 
     java.executable = ${java.home}${file.separator}bin${file.separator}java
     java.options = [

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -27,6 +27,7 @@
         function setHref() {
             document.getElementById( 'webui-link' ).href = window.location.protocol + "//" + window.location.hostname + ":8080/";
         }
+
     </script>
 </head>
 

--- a/src/main/resources/static/login.html
+++ b/src/main/resources/static/login.html
@@ -27,7 +27,7 @@
 <div class="main">
     <h1 class="heading">Polypheny Control</h1>
 
-    <div style="margin: auto; width: 30%; background-color: white; padding: 5%; border: 3px solid black;">
+    <div style="margin: auto; width: 30vw; background-color: white; padding: 5%; border: 3px solid black;">
         <h2>Login</h2>
         <div id="invalid" style="display: none;">
             <p style="color: red;">Invalid Credentials. Try Again.</p>
@@ -36,11 +36,11 @@
             <table>
                 <tr>
                     <td style="padding: 2%;">Name</td>
-                    <td style="padding: 2%;"><input id="name" type="text"></td>
+                    <td style="padding: 2%;"><input id="name" style="width: 20vw;" type="text"></td>
                 </tr>
                 <tr>
                     <td style="padding: 2%;">Password</td>
-                    <td style="padding: 2%;"><input id="password" type="password"></td>
+                    <td style="padding: 2%;"><input id="password" style="width: 20vw;" type="password"></td>
                 </tr>
                 <tr>
                     <td style="padding: 2%;"></td>

--- a/src/main/resources/static/login.html
+++ b/src/main/resources/static/login.html
@@ -1,0 +1,58 @@
+<!--
+  ~ Copyright 2017-2021 The Polypheny Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+    <title>Polypheny Control</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
+    <link rel="stylesheet" href="/style.css">
+</head>
+
+<body>
+<div class="main">
+    <h1 class="heading">Polypheny Control</h1>
+
+    <div style="margin: auto; width: 30%; background-color: white; padding: 5%; border: 3px solid black;">
+        <h2>Login</h2>
+        <div id="invalid" style="display: none;">
+            <p style="color: red;">Invalid Credentials. Try Again.</p>
+        </div>
+        <form onsubmit="return login();">
+            <table>
+                <tr>
+                    <td style="padding: 2%;">Name</td>
+                    <td style="padding: 2%;"><input id="name" type="text"></td>
+                </tr>
+                <tr>
+                    <td style="padding: 2%;">Password</td>
+                    <td style="padding: 2%;"><input id="password" type="password"></td>
+                </tr>
+                <tr>
+                    <td style="padding: 2%;"></td>
+                    <td style="padding: 2%;"><button type="submit">Login</button></td>
+                </tr>
+            </table>
+        </form>
+    </div>
+
+<script src="/jquery/3.5.1/jquery.js"></script>
+<script src="/login.js"></script>
+</div>
+</body>
+
+</html>

--- a/src/main/resources/static/login.js
+++ b/src/main/resources/static/login.js
@@ -2,9 +2,7 @@ function login() {
     let name = $('#name').val();
     let password = $('#password').val();
     let authHeader = "Basic " + btoa(name + ":" + password);
-    console.log(name);
-    console.log(password);
-    console.log(authHeader);
+
     $.ajax({
         url        : document.location.protocol + '//' + document.location.host + '/',
         type       : 'GET',

--- a/src/main/resources/static/login.js
+++ b/src/main/resources/static/login.js
@@ -1,0 +1,23 @@
+function login() {
+    let name = $('#name').val();
+    let password = $('#password').val();
+    let authHeader = "Basic " + btoa(name + ":" + password);
+    console.log(name);
+    console.log(password);
+    console.log(authHeader);
+    $.ajax({
+        url        : document.location.protocol + '//' + document.location.host + '/',
+        type       : 'GET',
+        headers    : {
+            "Authorization": authHeader
+        },
+        success    : function(data) {
+            document.location = document.location.protocol + '//' + document.location.host + '/'
+        },
+        error      : function(d, data) {
+            console.log(data);
+            $('#invalid').css('display', 'block');
+        },
+    });
+    return false;
+}

--- a/src/main/resources/static/login.js
+++ b/src/main/resources/static/login.js
@@ -13,7 +13,6 @@ function login() {
             document.location = document.location.protocol + '//' + document.location.host + '/'
         },
         error      : function(d, data) {
-            console.log(data);
             $('#invalid').css('display', 'block');
         },
     });

--- a/src/test/java/ControlTest.java
+++ b/src/test/java/ControlTest.java
@@ -32,6 +32,7 @@ import org.polypheny.control.client.ClientType;
 import org.polypheny.control.client.PolyphenyControlConnector;
 import org.polypheny.control.main.ControlCommand;
 
+
 public class ControlTest {
 
     private static Thread thread;

--- a/src/test/java/org/polypheny/control/ControlTest.java
+++ b/src/test/java/org/polypheny/control/ControlTest.java
@@ -30,6 +30,9 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.polypheny.control.authentication.AuthenticationDataManager;
+import org.polypheny.control.authentication.AuthenticationFileManager;
+import org.polypheny.control.client.ClientData;
 import org.polypheny.control.client.ClientType;
 import org.polypheny.control.client.PolyphenyControlConnector;
 import org.polypheny.control.main.ControlCommand;
@@ -47,6 +50,16 @@ public class ControlTest {
         if ( polyphenyDir.exists() ) {
             polyphenyDir.renameTo( new File( System.getProperty( "user.home" ), ".polypheny.backup" ) );
         }
+
+        // Create passwd data and an account
+        try {
+            FileUtils.forceMkdir( new File( System.getProperty( "user.home" ), ".polypheny" ) );
+        } catch ( IOException e ) {
+//            e.printStackTrace();
+        }
+        AuthenticationFileManager.getAuthenticationData();
+        AuthenticationDataManager.addAuthenticationData( "pc", "pc" );
+        AuthenticationFileManager.writeAuthenticationDataToFile();
 
         thread = new Thread( () -> (new ControlCommand())._run_() );
         thread.start();
@@ -68,7 +81,8 @@ public class ControlTest {
 
     @Test
     public void integrationTest() throws URISyntaxException, InterruptedException {
-        PolyphenyControlConnector controlConnector = new PolyphenyControlConnector( "localhost:8070", ClientType.BROWSER, null );
+        ClientData clientData = new ClientData( ClientType.BROWSER, "pc", "pc" );
+        PolyphenyControlConnector controlConnector = new PolyphenyControlConnector( "localhost:8070", clientData, null );
 
         // Update and build Polypheny
         controlConnector.updatePolypheny();


### PR DESCRIPTION
This PR implements authentication for Polypheny-Control, trying to solve issue [291](https://github.com/polypheny/Polypheny-DB/issues/291) Authentication information is stored in `.polypheny/passwd` file. This contains the username and password. The passwords are secured using the `crypt` function. However, the password file itself isn't secured. Users may find it much easier to use different commands on their computers to secure the password file. For eg, setting the immutable flag on Linux systems using the chattr command. To add / remove / modify users the polypheny-control executable has three commands `adduser`, `remuser` and `moduser`. They will modify the password file. So, if the file is secured by users using the immutable flag, it would have to be reset before performing these operations.
Authentication can be enabled / disabled for local users by using the `localauth.enable` config.
A login page has been added to the UI to ask for credentials. If credentials are invalid or is not done, user won't be able to access the index.html page.

Closes polypheny/Polypheny-DB#291